### PR TITLE
解决jackson 序列化日期变成类似[1942,4,2]的问题

### DIFF
--- a/src/main/java/com/github/gobars/httplog/springconfig/HttpLogWebMvcConf.java
+++ b/src/main/java/com/github/gobars/httplog/springconfig/HttpLogWebMvcConf.java
@@ -9,20 +9,20 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Slf4j
 @Configuration
 @AllArgsConstructor
-public class HttpLogWebMvcConf extends WebMvcConfigurationSupport {
+public class HttpLogWebMvcConf implements WebMvcConfigurer {
+
   final HttpLogInterceptor httpLogInterceptor;
   final HttpLogFilter httpLogFilter;
 
   @Override
-  protected void addInterceptors(InterceptorRegistry registry) {
+  public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(httpLogInterceptor).addPathPatterns("/**");
     log.info("Configure Interceptor.....");
-    super.addInterceptors(registry);
   }
 
   @Override


### PR DESCRIPTION
Motivation:
springboot返回结果时序列化日期格式数据变成[1942,4,2]这种格式的问题

Modifications:
用WebMvcConfigurer 替换WebMvcConfigurationSupport

Result:
日期格式可以按照配置的日期格式被序列化

引入WebMvcConfigurationSupport后，需要自己完全控制Spring MVC的配置，一种更安全的方式是实现WebMvcConfigurer接口。

参考：

https://stackoverflow.com/questions/45609569/setting-jackson-feature-write-dates-as-timestamps-not-working-in-spring-boot

https://www.cnblogs.com/myitnews/p/12329126.html