### PR TITLE
HttpLogFilter和HttpLogInterceptor添加静态资源uri过滤

### DIFF
--- a/src/main/java/com/github/gobars/httplog/Const.java
+++ b/src/main/java/com/github/gobars/httplog/Const.java
@@ -6,23 +6,4 @@ public interface Const {
   String PROCESSOR = "HTTPLOG_PROCESSOR";
   String INTERCEPTOR = "HTTPLOG_INTERCEPTOR";
   String CUSTOM = "HTTPLOG_CUSTOM";
-
-  String[] WEB_IGNORES =
-      new String[] {
-        "/css/**",
-        "/swagger-resources/**",
-        "/webjars/**",
-        "/v2/**",
-        "/doc.html",
-        "/i18n/**",
-        "/error",
-        "/**/*.ico",
-        "/service-worker.js",
-        "/precache-manifest.*.*",
-        "/index.html",
-        "/druid/**",
-        "/webjars/springfox-swagger-ui/**",
-        "/webjars/bycdao-ui/**"
-  };
-
 }

--- a/src/main/java/com/github/gobars/httplog/Const.java
+++ b/src/main/java/com/github/gobars/httplog/Const.java
@@ -6,4 +6,23 @@ public interface Const {
   String PROCESSOR = "HTTPLOG_PROCESSOR";
   String INTERCEPTOR = "HTTPLOG_INTERCEPTOR";
   String CUSTOM = "HTTPLOG_CUSTOM";
+
+  String[] WEB_IGNORES =
+      new String[] {
+        "/css/**",
+        "/swagger-resources/**",
+        "/webjars/**",
+        "/v2/**",
+        "/doc.html",
+        "/i18n/**",
+        "/error",
+        "/**/*.ico",
+        "/service-worker.js",
+        "/precache-manifest.*.*",
+        "/index.html",
+        "/druid/**",
+        "/webjars/springfox-swagger-ui/**",
+        "/webjars/bycdao-ui/**"
+  };
+
 }

--- a/src/main/java/com/github/gobars/httplog/HttpLogFilter.java
+++ b/src/main/java/com/github/gobars/httplog/HttpLogFilter.java
@@ -89,13 +89,12 @@ public class HttpLogFilter extends OncePerRequestFilter {
    */
   private boolean containIgnoreUris(String uri) {
     AntPathMatcher pathMatcher = new AntPathMatcher();
-    boolean flag = false;
     for (String ignore : httpLogWebIgnores) {
       if (pathMatcher.match(ignore, uri)) {
-        flag = true;
+        return true;
       }
     }
-    return flag;
+    return false;
   }
 
   private void tearDown(

--- a/src/main/java/com/github/gobars/httplog/HttpLogFilter.java
+++ b/src/main/java/com/github/gobars/httplog/HttpLogFilter.java
@@ -84,14 +84,17 @@ public class HttpLogFilter extends OncePerRequestFilter {
 
   /**
    * 校验uri是否为静态资源的URI
+   *
    * @param uri 需要校验的uri
    * @return
    */
   private boolean containIgnoreUris(String uri) {
-    AntPathMatcher pathMatcher = new AntPathMatcher();
-    for (String ignore : httpLogWebIgnores) {
-      if (pathMatcher.match(ignore, uri)) {
-        return true;
+    if (null != httpLogWebIgnores && httpLogWebIgnores.length > 0) {
+      AntPathMatcher pathMatcher = new AntPathMatcher();
+      for (String ignore : httpLogWebIgnores) {
+        if (pathMatcher.match(ignore, uri)) {
+          return true;
+        }
       }
     }
     return false;

--- a/src/main/java/com/github/gobars/httplog/HttpLogFilter.java
+++ b/src/main/java/com/github/gobars/httplog/HttpLogFilter.java
@@ -1,6 +1,5 @@
 package com.github.gobars.httplog;
 
-import static com.github.gobars.httplog.Const.WEB_IGNORES;
 import static java.util.Collections.list;
 
 import com.github.gobars.id.Id;
@@ -14,6 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -33,6 +33,10 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
  */
 @Slf4j
 public class HttpLogFilter extends OncePerRequestFilter {
+
+  @Autowired(required = false)
+  private String[] httpLogWebIgnores;
+
   @SneakyThrows
   @Override
   protected void doFilterInternal(HttpServletRequest r, HttpServletResponse s, FilterChain c) {
@@ -86,8 +90,8 @@ public class HttpLogFilter extends OncePerRequestFilter {
   private boolean containIgnoreUris(String uri) {
     AntPathMatcher pathMatcher = new AntPathMatcher();
     boolean flag = false;
-    for (String ignore : WEB_IGNORES) {
-      if (pathMatcher.match(ignore,uri)){
+    for (String ignore : httpLogWebIgnores) {
+      if (pathMatcher.match(ignore, uri)) {
         flag = true;
       }
     }

--- a/src/main/java/com/github/gobars/httplog/springconfig/HttpLogWebMvcConf.java
+++ b/src/main/java/com/github/gobars/httplog/springconfig/HttpLogWebMvcConf.java
@@ -5,7 +5,9 @@ import com.github.gobars.httplog.HttpLogFilter;
 import com.github.gobars.httplog.HttpLogInterceptor;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
@@ -17,10 +19,16 @@ public class HttpLogWebMvcConf extends WebMvcConfigurerAdapter {
   final HttpLogInterceptor httpLogInterceptor;
   final HttpLogFilter httpLogFilter;
 
+  @Autowired(required = false)
+  final String[] httpLogWebIgnores;
+
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
-    registry.addInterceptor(httpLogInterceptor).addPathPatterns("/**")
-    .excludePathPatterns(Const.WEB_IGNORES);
+    InterceptorRegistration i = registry.addInterceptor(httpLogInterceptor).addPathPatterns("/**");
+    if (httpLogWebIgnores.length > 0) {
+      i.excludePathPatterns(httpLogWebIgnores);
+    }
+
     log.info("Configure Interceptor.....");
     super.addInterceptors(registry);
   }

--- a/src/main/java/com/github/gobars/httplog/springconfig/HttpLogWebMvcConf.java
+++ b/src/main/java/com/github/gobars/httplog/springconfig/HttpLogWebMvcConf.java
@@ -1,5 +1,6 @@
 package com.github.gobars.httplog.springconfig;
 
+import com.github.gobars.httplog.Const;
 import com.github.gobars.httplog.HttpLogFilter;
 import com.github.gobars.httplog.HttpLogInterceptor;
 import lombok.AllArgsConstructor;
@@ -18,7 +19,8 @@ public class HttpLogWebMvcConf extends WebMvcConfigurerAdapter {
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
-    registry.addInterceptor(httpLogInterceptor).addPathPatterns("/**");
+    registry.addInterceptor(httpLogInterceptor).addPathPatterns("/**")
+    .excludePathPatterns(Const.WEB_IGNORES);
     log.info("Configure Interceptor.....");
     super.addInterceptors(registry);
   }

--- a/src/main/java/com/github/gobars/httplog/springconfig/HttpLogWebMvcConf.java
+++ b/src/main/java/com/github/gobars/httplog/springconfig/HttpLogWebMvcConf.java
@@ -1,7 +1,5 @@
 package com.github.gobars.httplog.springconfig;
 
-import com.github.gobars.httplog.Const;
-import com.github.gobars.httplog.HttpLogFilter;
 import com.github.gobars.httplog.HttpLogInterceptor;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +15,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 public class HttpLogWebMvcConf extends WebMvcConfigurerAdapter {
 
   final HttpLogInterceptor httpLogInterceptor;
-  final HttpLogFilter httpLogFilter;
 
   @Autowired(required = false)
   final String[] httpLogWebIgnores;

--- a/src/main/java/com/github/gobars/httplog/springconfig/HttpLogWebMvcConf.java
+++ b/src/main/java/com/github/gobars/httplog/springconfig/HttpLogWebMvcConf.java
@@ -22,7 +22,7 @@ public class HttpLogWebMvcConf extends WebMvcConfigurerAdapter {
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     InterceptorRegistration i = registry.addInterceptor(httpLogInterceptor).addPathPatterns("/**");
-    if (httpLogWebIgnores.length > 0) {
+    if (null != httpLogWebIgnores && httpLogWebIgnores.length > 0) {
       i.excludePathPatterns(httpLogWebIgnores);
     }
 

--- a/src/test/java/com/github/gobars/httplog/spring/mysql/App.java
+++ b/src/test/java/com/github/gobars/httplog/spring/mysql/App.java
@@ -40,4 +40,9 @@ public class App {
 
     return HttpLogTags.parseYml(is);
   }
+
+  @Bean
+  public String[] httpLogWebIgnores() {
+    return new String[]{};
+  }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34856518/123221598-af707b00-d501-11eb-9364-ff4e1083e182.png)
1.当httplogfilter处理静态资源时，会打印warn日志，直接过滤静态资源路径，不做处理。
2.直接在配置中排除静态资源路径，不用再进入Interceptor处理，提高效率。